### PR TITLE
Previous characters should be set to empty if used

### DIFF
--- a/Tailf/Tail.cs
+++ b/Tailf/Tail.cs
@@ -127,6 +127,7 @@ namespace Tailf
                                             if (current.Length > 0)
                                             {
                                                 string line = string.Concat(previous, current);
+                                                previous = "";
 
                                                 if (lineFilterRegex.IsMatch(line))
                                                 {


### PR DESCRIPTION
If the previous characters are not set to empty they will be added to every new line.